### PR TITLE
feat(MemFS): make MemFS actually do something

### DIFF
--- a/mem.go
+++ b/mem.go
@@ -1,18 +1,25 @@
 package qfs
 
-import "fmt"
-
-// NewMemFS creates an in-memory filesystem from a set of files
-func NewMemFS(files ...File) *MemFS {
-	return &MemFS{}
+// MemFSStore is the minimum interface for creating a MemFS
+type MemFSStore interface {
+	Get(path string) (File, error)
 }
 
-// MemFS is an in-memory implementation
-// It currently doesn't work, this is just a placeholder for upstream code
+// NewMemFS creates an in-memory filesystem from a set of files
+func NewMemFS(store MemFSStore) *MemFS {
+	return &MemFS{
+		store: store,
+	}
+}
+
+// MemFS is an in-memory implementation of the FileSystem interface. it's a
+// minimal wrapper around anything that supports getting a file with a
+// string key
 type MemFS struct {
+	store MemFSStore
 }
 
 // Get implements PathResolver interface
 func (mfs *MemFS) Get(path string) (File, error) {
-	return nil, fmt.Errorf("memfs is not yet finished")
+	return mfs.store.Get(path)
 }

--- a/mem.go
+++ b/mem.go
@@ -1,12 +1,7 @@
 package qfs
 
-// MemFSStore is the minimum interface for creating a MemFS
-type MemFSStore interface {
-	Get(path string) (File, error)
-}
-
 // NewMemFS creates an in-memory filesystem from a set of files
-func NewMemFS(store MemFSStore) *MemFS {
+func NewMemFS(store Filesystem) *MemFS {
 	return &MemFS{
 		store: store,
 	}
@@ -16,7 +11,7 @@ func NewMemFS(store MemFSStore) *MemFS {
 // minimal wrapper around anything that supports getting a file with a
 // string key
 type MemFS struct {
-	store MemFSStore
+	store Filesystem
 }
 
 // Get implements PathResolver interface

--- a/mem_test.go
+++ b/mem_test.go
@@ -1,0 +1,34 @@
+package qfs
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+)
+
+func TestMemFS(t *testing.T) {
+	memfs := NewMemFS(testStore(0))
+	f, err := memfs.Get("path")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(data, []byte(`data`)) {
+		t.Errorf("byte mismatch. expected: %s. got: %s", `data`, string(data))
+	}
+}
+
+type testStore int
+
+func (t testStore) Get(path string) (File, error) {
+	if path == "path" {
+		return NewMemfileBytes("path", []byte(`data`)), nil
+	}
+
+	return nil, ErrNotFound
+}


### PR DESCRIPTION
we need MemFS to do something for tests upstream in qri-io/base/render_test.go, so let's just make it happen.

Changing the signature of NewMemFS is going to break stuff upstream in qri, which I'll fix in qri-io/qri#724