### PR TITLE
feat(destroyer): add destroyer interface

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -28,6 +28,12 @@ type Filesystem interface {
 	PathResolver
 }
 
+// Destroyer is an optional interface to tear down a filesystem, removing all
+// persisted resources
+type Destroyer interface {
+	Destroy() error
+}
+
 // AbsPath adjusts the provided string to a path lib functions can work with
 // because paths for Qri can come from the local filesystem, an http url, or
 // the distributed web, Absolutizing is a little tricky


### PR DESCRIPTION
our tests sometimes need a "cleanup" function that removes files created by the test. I think we should instead switch to using an opt-in "destroyer" interface, that tests can check for and call if needed. Destroy can also be used in production code for the same teardown purposes