### PR TITLE
refactor(contxt): require context on exported interfaces

### DIFF
--- a/cafs/ipfs/filestore.go
+++ b/cafs/ipfs/filestore.go
@@ -125,25 +125,25 @@ func (fst *Filestore) GoOnline(ctx context.Context) error {
 	return nil
 }
 
-func (fst *Filestore) Has(key string) (exists bool, err error) {
+func (fst *Filestore) Has(ctx context.Context, key string) (exists bool, err error) {
 
 	// TODO (b5) - we should be scrutinizing the error that's returned here:
-	if _, err = fst.node.Resolver.ResolvePath(fst.node.Context(), putil.Path(key)); err != nil {
+	if _, err = fst.node.Resolver.ResolvePath(ctx, putil.Path(key)); err != nil {
 		return false, nil
 	}
 
 	return true, nil
 }
 
-func (fst *Filestore) Get(key string) (qfs.File, error) {
-	return fst.getKey(key)
+func (fst *Filestore) Get(ctx context.Context, key string) (qfs.File, error) {
+	return fst.getKey(ctx, key)
 }
 
-func (fst *Filestore) Fetch(source cafs.Source, key string) (qfs.File, error) {
-	return fst.getKey(key)
+func (fst *Filestore) Fetch(ctx context.Context, source cafs.Source, key string) (qfs.File, error) {
+	return fst.getKey(ctx, key)
 }
 
-func (fst *Filestore) Put(file qfs.File, pin bool) (key string, err error) {
+func (fst *Filestore) Put(ctx context.Context, file qfs.File, pin bool) (key string, err error) {
 	hash, err := fst.AddFile(file, pin)
 	if err != nil {
 		log.Infof("error adding bytes: %s", err.Error())
@@ -152,8 +152,8 @@ func (fst *Filestore) Put(file qfs.File, pin bool) (key string, err error) {
 	return pathFromHash(hash), nil
 }
 
-func (fst *Filestore) Delete(key string) error {
-	err := fst.Unpin(key, true)
+func (fst *Filestore) Delete(ctx context.Context, key string) error {
+	err := fst.Unpin(ctx, key, true)
 	if err != nil {
 		if err.Error() == "not pinned" {
 			return nil
@@ -162,8 +162,8 @@ func (fst *Filestore) Delete(key string) error {
 	return nil
 }
 
-func (fst *Filestore) getKey(key string) (qfs.File, error) {
-	node, err := fst.capi.Unixfs().Get(fst.node.Context(), path.New(key))
+func (fst *Filestore) getKey(ctx context.Context, key string) (qfs.File, error) {
+	node, err := fst.capi.Unixfs().Get(ctx, path.New(key))
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ type Adder struct {
 	pin   bool
 }
 
-func (a *Adder) AddFile(f qfs.File) error {
+func (a *Adder) AddFile(ctx context.Context, f qfs.File) error {
 	return a.adder.AddFile(wrapFile{f})
 }
 
@@ -356,12 +356,12 @@ func (fst *Filestore) AddFile(file qfs.File, pin bool) (hash string, err error) 
 	return
 }
 
-func (fst *Filestore) Pin(cid string, recursive bool) error {
-	return fst.capi.Pin().Add(context.Background(), path.New(cid))
+func (fst *Filestore) Pin(ctx context.Context, cid string, recursive bool) error {
+	return fst.capi.Pin().Add(ctx, path.New(cid))
 }
 
-func (fst *Filestore) Unpin(cid string, recursive bool) error {
-	return fst.capi.Pin().Rm(context.Background(), path.New(cid))
+func (fst *Filestore) Unpin(ctx context.Context, cid string, recursive bool) error {
+	return fst.capi.Pin().Rm(ctx, path.New(cid))
 }
 
 type wrapFile struct {

--- a/cafs/ipfs/filestore_test.go
+++ b/cafs/ipfs/filestore_test.go
@@ -1,6 +1,7 @@
 package ipfs_filestore
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"os"
@@ -51,6 +52,7 @@ func TestFilestore(t *testing.T) {
 }
 
 func BenchmarkRead(b *testing.B) {
+	ctx := context.Background()
 	path := filepath.Join(os.TempDir(), "ipfs_cafs_benchmark_read")
 
 	if _, err := os.Open(filepath.Join(path, "config")); os.IsNotExist(err) {
@@ -83,7 +85,7 @@ func BenchmarkRead(b *testing.B) {
 		return
 	}
 
-	key, err := f.Put(qfs.NewMemfileBytes(filepath.Base(egFilePath), data), true)
+	key, err := f.Put(ctx, qfs.NewMemfileBytes(filepath.Base(egFilePath), data), true)
 	if err != nil {
 		b.Errorf("error putting example file in store: %s", err.Error())
 		return
@@ -91,7 +93,7 @@ func BenchmarkRead(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		gotf, err := f.Get(key)
+		gotf, err := f.Get(ctx, key)
 		if err != nil {
 			b.Errorf("iteration %d error getting key: %s", i, err.Error())
 			break

--- a/cafs/ipfs_http/filestore.go
+++ b/cafs/ipfs_http/filestore.go
@@ -51,7 +51,7 @@ func (fst *Filestore) Online() bool {
 	return true
 }
 
-func (fst *Filestore) Has(key string) (exists bool, err error) {
+func (fst *Filestore) Has(ctx context.Context, key string) (exists bool, err error) {
 	return false, fmt.Errorf("ipfs_http hasn't implemented has yet")
 	// // TODO (b5) - we should be scrutinizing the error that's returned here:
 	// if _, err = fst.node.Resolver.ResolvePath(fst.node.Context(), putil.Path(key)); err != nil {
@@ -61,20 +61,20 @@ func (fst *Filestore) Has(key string) (exists bool, err error) {
 	// return true, nil
 }
 
-func (fst *Filestore) Get(key string) (qfs.File, error) {
-	return fst.getKey(key)
+func (fst *Filestore) Get(ctx context.Context, key string) (qfs.File, error) {
+	return fst.getKey(ctx, key)
 }
 
-func (fst *Filestore) Fetch(source cafs.Source, key string) (qfs.File, error) {
-	return fst.getKey(key)
+func (fst *Filestore) Fetch(ctx context.Context, source cafs.Source, key string) (qfs.File, error) {
+	return fst.getKey(ctx, key)
 }
 
-func (fst *Filestore) Put(file qfs.File, pin bool) (key string, err error) {
+func (fst *Filestore) Put(ctx context.Context, file qfs.File, pin bool) (key string, err error) {
 	return "", fmt.Errorf("ipfs_http cannot put")
 }
 
-func (fst *Filestore) Delete(key string) error {
-	err := fst.Unpin(key, true)
+func (fst *Filestore) Delete(ctx context.Context, key string) error {
+	err := fst.Unpin(ctx, key, true)
 	if err != nil {
 		if err.Error() == "not pinned" {
 			return nil
@@ -83,8 +83,8 @@ func (fst *Filestore) Delete(key string) error {
 	return nil
 }
 
-func (fst *Filestore) getKey(key string) (qfs.File, error) {
-	node, err := fst.capi.Unixfs().Get(context.TODO(), path.New(key))
+func (fst *Filestore) getKey(ctx context.Context, key string) (qfs.File, error) {
+	node, err := fst.capi.Unixfs().Get(ctx, path.New(key))
 	if err != nil {
 		return nil, err
 	}
@@ -109,16 +109,16 @@ func pathFromHash(hash string) string {
 }
 
 // AddFile adds a file to the top level IPFS Node
-func (fst *Filestore) AddFile(file qfs.File, pin bool) (hash string, err error) {
+func (fst *Filestore) AddFile(ctx context.Context, file qfs.File, pin bool) (hash string, err error) {
 	return "", fmt.Errorf("ipfs_http doesn't support adding")
 }
 
-func (fst *Filestore) Pin(cid string, recursive bool) error {
-	return fst.capi.Pin().Add(context.Background(), path.New(cid))
+func (fst *Filestore) Pin(ctx context.Context, cid string, recursive bool) error {
+	return fst.capi.Pin().Add(ctx, path.New(cid))
 }
 
-func (fst *Filestore) Unpin(cid string, recursive bool) error {
-	return fst.capi.Pin().Rm(context.Background(), path.New(cid))
+func (fst *Filestore) Unpin(ctx context.Context, cid string, recursive bool) error {
+	return fst.capi.Pin().Rm(ctx, path.New(cid))
 }
 
 type wrapFile struct {

--- a/fs.go
+++ b/fs.go
@@ -1,6 +1,7 @@
 package qfs
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -18,7 +19,7 @@ var (
 // * content-addressed file systems like IPFS or Git
 // Datasets & dataset components use a filesource to resolve string references
 type PathResolver interface {
-	Get(path string) (File, error)
+	Get(ctx context.Context, path string) (File, error)
 }
 
 // Filesystem abstracts & unifies filesystem-like behaviour

--- a/go.mod
+++ b/go.mod
@@ -38,5 +38,5 @@ require (
 	github.com/multiformats/go-multihash v0.0.5
 	golang.org/x/net v0.0.0-20190522155817-f3200d17e092 // indirect
 	golang.org/x/sys v0.0.0-20190610200419-93c9922d18ae
-	google.golang.org/appengine v1.4.0 // indirect
+	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJY
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-critic/go-critic v0.0.0-20181204210945-c3db6069acc5/go.mod h1:Jc75BZJv2dNy7opKH6bF29VveDQHfGZ6Asn/3phBesg=
 github.com/go-critic/go-critic v0.0.0-20181204210945-ee9bf5809ead/go.mod h1:3MzXZKJdeXqdU9cj+rvZdNiN7SZ8V9OjybF8loZDmHU=
+github.com/go-critic/go-critic v0.0.0-20190210220443-ee9bf5809ead/go.mod h1:3MzXZKJdeXqdU9cj+rvZdNiN7SZ8V9OjybF8loZDmHU=
+github.com/go-critic/go-critic v0.0.0-20190422201921-c3db6069acc5/go.mod h1:Jc75BZJv2dNy7opKH6bF29VveDQHfGZ6Asn/3phBesg=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTDqfpXvXAN0sXM=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -109,15 +111,20 @@ github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8l
 github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2/go.mod h1:k9Qvh+8juN+UKMCS/3jFtGICgW8O96FVaZsaxdzDkR4=
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a/go.mod h1:ryS0uhF+x9jgbj/N71xsEqODy9BN81/GonCZiOzirOk=
 github.com/golangci/errcheck v0.0.0-20181003203344-ef45e06d44b6/go.mod h1:DbHgvLiFKX1Sh2T1w8Q/h4NAI8MHIpzCdnBUDTXU3I0=
+github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6/go.mod h1:DbHgvLiFKX1Sh2T1w8Q/h4NAI8MHIpzCdnBUDTXU3I0=
 github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613/go.mod h1:SyvUF2NxV+sN8upjjeVYr5W7tyxaT1JVtvhKhOn2ii8=
 github.com/golangci/go-tools v0.0.0-20180109140146-af6baa5dc196/go.mod h1:unzUULGw35sjyOYjUt0jMTXqHlZPpPc6e+xfO4cd6mM=
+github.com/golangci/go-tools v0.0.0-20190318060251-af6baa5dc196/go.mod h1:unzUULGw35sjyOYjUt0jMTXqHlZPpPc6e+xfO4cd6mM=
 github.com/golangci/goconst v0.0.0-20180610141641-041c5f2b40f3/go.mod h1:JXrF4TWy4tXYn62/9x8Wm/K/dm06p8tCKwFRDPZG/1o=
 github.com/golangci/gocyclo v0.0.0-20180528134321-2becd97e67ee/go.mod h1:ozx7R9SIwqmqf5pRP90DhR2Oay2UIjGuKheCBCNwAYU=
 github.com/golangci/gofmt v0.0.0-20181105071733-0b8337e80d98/go.mod h1:9qCChq59u/eW8im404Q2WWTrnBUQKjpNYKMbU4M7EFU=
+github.com/golangci/gofmt v0.0.0-20181222123516-0b8337e80d98/go.mod h1:9qCChq59u/eW8im404Q2WWTrnBUQKjpNYKMbU4M7EFU=
 github.com/golangci/golangci-lint v1.16.1-0.20190425135923-692dacb773b7/go.mod h1:kSe2pu2LlcsMT5Dr95yNKUT5RNfMkwif9MZqtOW5NEs=
 github.com/golangci/gosec v0.0.0-20180901114220-66fb7fc33547/go.mod h1:0qUabqiIQgfmlAmulqxyiGkkyF6/tOGSnY2cnPVwrzU=
+github.com/golangci/gosec v0.0.0-20190211064107-66fb7fc33547/go.mod h1:0qUabqiIQgfmlAmulqxyiGkkyF6/tOGSnY2cnPVwrzU=
 github.com/golangci/ineffassign v0.0.0-20180808204949-2ee8f2867dde/go.mod h1:e5tpTHCfVze+7EpLEozzMB3eafxo2KT5veNg1k6byQU=
 github.com/golangci/lint-1 v0.0.0-20180610141402-ee948d087217/go.mod h1:66R6K6P6VWk9I95jvqGxkqJxVWGFy9XlDwLwVz1RCFg=
+github.com/golangci/lint-1 v0.0.0-20190420132249-ee948d087217/go.mod h1:66R6K6P6VWk9I95jvqGxkqJxVWGFy9XlDwLwVz1RCFg=
 github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca/go.mod h1:tvlJhZqDe4LMs4ZHD0oMUlt9G2LWuDGoisJTBzLMV9o=
 github.com/golangci/misspell v0.0.0-20180809174111-950f5d19e770/go.mod h1:dEbvlSfYbMQDtrpRMQU675gSDLDNa8sCPPChZ7PhiVA=
 github.com/golangci/prealloc v0.0.0-20180630174525-215b22d4de21/go.mod h1:tf5+bzsHdTM0bsB7+8mt0GUMvjCgwLpTapNZHU8AajI=
@@ -763,6 +770,8 @@ golang.org/x/xerrors v0.0.0-20190212162355-a5947ffaace3 h1:P6iTFmrTQqWrqLZPX1VMz
 golang.org/x/xerrors v0.0.0-20190212162355-a5947ffaace3/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -792,4 +801,5 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190124213536-fbb59629db34/go.mod h1:H6SUd1XjIs+qQCyskXg5OFSrilMRUkD8ePJpHKDPaeY=
+mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34/go.mod h1:H6SUd1XjIs+qQCyskXg5OFSrilMRUkD8ePJpHKDPaeY=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=

--- a/httpfs/httpfs.go
+++ b/httpfs/httpfs.go
@@ -1,6 +1,7 @@
 package httpfs
 
 import (
+	"context"
 	"net/http"
 	"path/filepath"
 
@@ -46,8 +47,13 @@ type FS struct {
 }
 
 // Get implements qfs.PathResolver
-func (httpfs *FS) Get(path string) (qfs.File, error) {
-	resp, err := httpfs.cfg.Client.Get(path)
+func (httpfs *FS) Get(ctx context.Context, path string) (qfs.File, error) {
+	req, err := http.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	resp, err := httpfs.cfg.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/localfs/localfs.go
+++ b/localfs/localfs.go
@@ -1,6 +1,7 @@
 package localfs
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -47,7 +48,7 @@ type FS struct {
 }
 
 // Get implements qfs.PathResolver
-func (lfs *FS) Get(path string) (qfs.File, error) {
+func (lfs *FS) Get(ctx context.Context, path string) (qfs.File, error) {
 	fi, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/mem.go
+++ b/mem.go
@@ -1,5 +1,7 @@
 package qfs
 
+import "context"
+
 // NewMemFS creates an in-memory filesystem from a set of files
 func NewMemFS(store Filesystem) *MemFS {
 	return &MemFS{
@@ -15,6 +17,6 @@ type MemFS struct {
 }
 
 // Get implements PathResolver interface
-func (mfs *MemFS) Get(path string) (File, error) {
-	return mfs.store.Get(path)
+func (mfs *MemFS) Get(ctx context.Context, path string) (File, error) {
+	return mfs.store.Get(ctx, path)
 }

--- a/mem_test.go
+++ b/mem_test.go
@@ -3,12 +3,14 @@ package qfs
 import (
 	"bytes"
 	"io/ioutil"
+	"context"
 	"testing"
 )
 
 func TestMemFS(t *testing.T) {
+	ctx := context.Background()
 	memfs := NewMemFS(testStore(0))
-	f, err := memfs.Get("path")
+	f, err := memfs.Get(ctx, "path")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +27,7 @@ func TestMemFS(t *testing.T) {
 
 type testStore int
 
-func (t testStore) Get(path string) (File, error) {
+func (t testStore) Get(ctx context.Context, path string) (File, error) {
 	if path == "path" {
 		return NewMemfileBytes("path", []byte(`data`)), nil
 	}

--- a/muxfs/muxfs.go
+++ b/muxfs/muxfs.go
@@ -1,6 +1,7 @@
 package muxfs
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/qri-io/qfs"
@@ -26,12 +27,12 @@ func (m *Mux) SetHandler(pathKind string, resolver qfs.PathResolver) {
 }
 
 // Get impoements the qfs.PathResolver interface
-func (m Mux) Get(path string) (qfs.File, error) {
+func (m Mux) Get(ctx context.Context, path string) (qfs.File, error) {
 	kind := qfs.PathKind(path)
 	handler, ok := m.handlers[kind]
 	if !ok {
 		return nil, fmt.Errorf("cannot resolve paths of kind '%s'. path: %s", kind, path)
 	}
 
-	return handler.Get(path)
+	return handler.Get(ctx, path)
 }


### PR DESCRIPTION
high-time we used contexts on qfs.