### PR TITLE
refactor(muxfs): add `GetHandler` and `GetResolver` functions

### DIFF
--- a/cafs/mapstore.go
+++ b/cafs/mapstore.go
@@ -21,6 +21,11 @@ func NewMapstore() *MapStore {
 	}
 }
 
+// NewMapFilesystem satisfies the qfs.FSConstructor interface
+func NewMapFilesystem(ctgMap map[string]interface{}) (qfs.Filesystem, error) {
+	return NewMapstore(), nil
+}
+
 // MapStore implements Filestore in-memory as a map
 //
 // An example pulled from tests will create a tree of "cafs"

--- a/fs.go
+++ b/fs.go
@@ -83,8 +83,10 @@ func PathKind(path string) string {
 		return "http"
 	} else if strings.HasPrefix(path, "/ipfs") {
 		return "ipfs"
-	} else if strings.HasPrefix(path, "/map") || strings.HasPrefix(path, "/mem") {
+	} else if strings.HasPrefix(path, "/mem") {
 		return "mem"
+	} else if strings.HasPrefix(path, "/map") {
+		return "map"
 	}
 	return "local"
 }

--- a/fs_test.go
+++ b/fs_test.go
@@ -56,7 +56,8 @@ func TestPathKind(t *testing.T) {
 		{"/path/to/location", "local"},
 		{"/", "local"},
 		{"/ipfs/Qmfoo", "ipfs"},
-		{"/map/Qmfoo", "mem"},
+		{"/mem/Qmfoo", "mem"},
+		{"/map/Qmfoo", "map"},
 	}
 
 	for i, c := range cases {

--- a/muxfs/mux.go
+++ b/muxfs/mux.go
@@ -33,6 +33,13 @@ func (m *Mux) SetHandler(pathKind string, resolver qfs.Filesystem) {
 	m.handlers[pathKind] = resolver
 }
 
+// GetHandler returns the resolver for a given path kind string and a bool
+// if the resolver exists on the muxfs
+func (m *Mux) GetHandler(pathKind string) (qfs.Filesystem, bool) {
+	resolver, ok := m.handlers[pathKind]
+	return resolver, ok
+}
+
 // Option is a function that manipulates config details when fed to New(). Fields on
 // the o parameter may be null, functions cannot assume the Config is non-null.
 type Option func(o *[]MuxConfig) error
@@ -158,4 +165,18 @@ func (m *Mux) CAFSStoreFromIPFS() cafs.Filestore {
 		return nil
 	}
 	return ipfsFS.(cafs.Filestore)
+}
+
+// GetResolver returns a resolver of a certain kind from a qfs.Filesystem if
+// that filesystem is a muxfs
+func GetResolver(fs qfs.Filesystem, pathKind string) (qfs.Filesystem, error) {
+	m, ok := fs.(*Mux)
+	if !ok {
+		return nil, fmt.Errorf("file system is not a mux filesystem and does not have multiple resolvers")
+	}
+	resolver, ok := m.GetHandler(pathKind)
+	if !ok {
+		return nil, fmt.Errorf("resolver of kind '%s' does not exist on this filesystem", pathKind)
+	}
+	return resolver, nil
 }

--- a/muxfs/mux.go
+++ b/muxfs/mux.go
@@ -57,6 +57,7 @@ var constructors = map[string]qfs.FSConstructor{
 	"local": localfs.NewFilesystem,
 	"http":  httpfs.NewFilesystem,
 	"mem":   qfs.NewMemFilesystem,
+	"map":   cafs.NewMapFilesystem,
 }
 
 // New creates a new Mux Filesystem, if no Option funcs are provided,
@@ -78,7 +79,7 @@ func New(ctx context.Context, cfgs []MuxConfig, opts ...Option) (*Mux, error) {
 	for _, cfg := range cfgs {
 		constructor, ok := constructors[cfg.Type]
 		if !ok {
-			return nil, fmt.Errorf("unrecognized filsystem type: %q", cfg.Type)
+			return nil, fmt.Errorf("unrecognized filesystem type: %q", cfg.Type)
 		}
 		fs, err := constructor(cfg.Config)
 		if err != nil {

--- a/muxfs/mux_test.go
+++ b/muxfs/mux_test.go
@@ -42,17 +42,17 @@ func TestDefaultNewMux(t *testing.T) {
 		t.Errorf("error creating new mux: %s", err)
 		return
 	}
-	if _, ok := mfs.handlers["ipfs"]; !ok {
-		t.Errorf("expected 'ipfs' filesystem, got none")
+	if _, err := GetResolver(mfs, "ipfs"); err != nil {
+		t.Errorf(err.Error())
 	}
-	if _, ok := mfs.handlers["http"]; !ok {
-		t.Errorf("expected 'http' filesystem, got none")
+	if _, err := GetResolver(mfs, "http"); err != nil {
+		t.Errorf(err.Error())
 	}
-	if _, ok := mfs.handlers["local"]; !ok {
-		t.Errorf("expected 'local' filesystem, got none")
+	if _, err := GetResolver(mfs, "local"); err != nil {
+		t.Errorf(err.Error())
 	}
-	if _, ok := mfs.handlers["mem"]; !ok {
-		t.Errorf("expected 'mem' filesystem, got none")
+	if _, err := GetResolver(mfs, "mem"); err != nil {
+		t.Errorf(err.Error())
 	}
 }
 

--- a/muxfs/mux_test.go
+++ b/muxfs/mux_test.go
@@ -36,6 +36,7 @@ func TestDefaultNewMux(t *testing.T) {
 		{Type: "http"},
 		{Type: "local"},
 		{Type: "mem"},
+		{Type: "map"},
 	}
 	mfs, err := New(ctx, cfg)
 	if err != nil {
@@ -52,6 +53,9 @@ func TestDefaultNewMux(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 	if _, err := GetResolver(mfs, "mem"); err != nil {
+		t.Errorf(err.Error())
+	}
+	if _, err := GetResolver(mfs, "map"); err != nil {
 		t.Errorf(err.Error())
 	}
 }


### PR DESCRIPTION
also adds `map` as a separate muxfs constructor option

I didn't understand that `mem` (the in-memory `qfs.Filesystem` implimentation) and `map` (the in-memory `cafs.Filestore` implimentation) were different and really needed their own slots in a muxfs

These changes are in service of refactoring Qri, `lib.NewInstance` specifically