### PR TITLE
refactor(`RunMigrations`): func that copies, migrates, and moves the ipfs

### DIFF
--- a/cafs/ipfs/config.go
+++ b/cafs/ipfs/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/ipfs/go-ipfs/core"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
@@ -118,16 +117,16 @@ func (cfg *StoreCfg) InitRepo(ctx context.Context) error {
 // MoveIPFSRepoOntoPath moves the ipfs repo from wherever it is,
 // indicated by the store config, to live on the given path
 // this changes the path in the given config struct
-func MoveIPFSRepoOntoPath(o *StoreCfg, path string) error {
-	if path == "" {
+func MoveIPFSRepoOntoPath(repoPath, newPath string) error {
+	if repoPath == "" {
+		return fmt.Errorf("need the path to the ipfs repo")
+	}
+	if newPath == "" {
 		return fmt.Errorf("need a path onto which the ipfs repo should be moved")
 	}
 
-	newIPFSPath := filepath.Join(path, filepath.Base(o.FsRepoPath))
-
-	if err := os.Rename(o.FsRepoPath, newIPFSPath); err != nil {
+	if err := os.Rename(repoPath, newPath); err != nil {
 		return err
 	}
-	o.FsRepoPath = newIPFSPath
 	return nil
 }

--- a/cafs/ipfs/config.go
+++ b/cafs/ipfs/config.go
@@ -3,7 +3,6 @@ package ipfs_filestore
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/ipfs/go-ipfs/core"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
@@ -114,19 +113,3 @@ func (cfg *StoreCfg) InitRepo(ctx context.Context) error {
 	return nil
 }
 
-// MoveIPFSRepoOntoPath moves the ipfs repo from wherever it is,
-// indicated by the store config, to live on the given path
-// this changes the path in the given config struct
-func MoveIPFSRepoOntoPath(repoPath, newPath string) error {
-	if repoPath == "" {
-		return fmt.Errorf("need the path to the ipfs repo")
-	}
-	if newPath == "" {
-		return fmt.Errorf("need a path onto which the ipfs repo should be moved")
-	}
-
-	if err := os.Rename(repoPath, newPath); err != nil {
-		return err
-	}
-	return nil
-}

--- a/cafs/ipfs/config_test.go
+++ b/cafs/ipfs/config_test.go
@@ -26,10 +26,6 @@ func TestMoveIPFSRepoOnToQriPath(t *testing.T) {
 		return
 	}
 
-	cfg := &StoreCfg{
-		FsRepoPath: ipfsPath,
-	}
-
 	if _, err := os.Stat(qriPath); os.IsNotExist(err) {
 		t.Errorf("error: qriPath directory was not created")
 		return
@@ -39,7 +35,9 @@ func TestMoveIPFSRepoOnToQriPath(t *testing.T) {
 		return
 	}
 
-	if err := MoveIPFSRepoOntoPath(cfg, qriPath); err != nil {
+	newIpfsPath := filepath.Join(qriPath, ".ipfs")
+
+	if err := MoveIPFSRepoOntoPath(ipfsPath, newIpfsPath); err != nil {
 		t.Errorf("MoveIPFSRepoOntoPath error: %s", err)
 		return
 	}
@@ -52,10 +50,6 @@ func TestMoveIPFSRepoOnToQriPath(t *testing.T) {
 
 	if _, err := os.Stat(newIPFSPath); os.IsNotExist(err) {
 		t.Errorf("IPFS repo was not moved onto the new IPFS path: %s", newIPFSPath)
-		return
-	}
-	if cfg.FsRepoPath != newIPFSPath {
-		t.Errorf("FsRepoPath in Store Config object was not changed")
 		return
 	}
 }

--- a/cafs/ipfs/config_test.go
+++ b/cafs/ipfs/config_test.go
@@ -1,58 +1,8 @@
 package ipfs_filestore
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 )
-
-func TestMoveIPFSRepoOnToQriPath(t *testing.T) {
-	path := filepath.Join(os.TempDir(), "ipfs_repo_move_test")
-	if err := os.MkdirAll(path, 0755); err != nil {
-		t.Errorf("error creating temp dir: %s", err.Error())
-		return
-	}
-	defer os.RemoveAll(path)
-
-	qriPath := filepath.Join(path, ".qri")
-	ipfsPath := filepath.Join(path, ".ipfs")
-
-	if err := os.MkdirAll(qriPath, 0755); err != nil {
-		t.Errorf("error creating temp qri dir: %s", err.Error())
-		return
-	}
-	if err := os.MkdirAll(ipfsPath, 0755); err != nil {
-		t.Errorf("error creating temp ipfs dir: %s", err.Error())
-		return
-	}
-
-	if _, err := os.Stat(qriPath); os.IsNotExist(err) {
-		t.Errorf("error: qriPath directory was not created")
-		return
-	}
-	if _, err := os.Stat(ipfsPath); os.IsNotExist(err) {
-		t.Errorf("error: ipfsPath directory was not created")
-		return
-	}
-
-	newIpfsPath := filepath.Join(qriPath, ".ipfs")
-
-	if err := MoveIPFSRepoOntoPath(ipfsPath, newIpfsPath); err != nil {
-		t.Errorf("MoveIPFSRepoOntoPath error: %s", err)
-		return
-	}
-
-	newIPFSPath := filepath.Join(qriPath, ".ipfs")
-	if _, err := os.Stat(ipfsPath); !os.IsNotExist(err) {
-		t.Errorf("old ipfs dir should not exist")
-		return
-	}
-
-	if _, err := os.Stat(newIPFSPath); os.IsNotExist(err) {
-		t.Errorf("IPFS repo was not moved onto the new IPFS path: %s", newIPFSPath)
-		return
-	}
-}
 
 func TestMapToConfig(t *testing.T) {
 	m := map[string]interface{}{

--- a/cafs/ipfs/migrate.go
+++ b/cafs/ipfs/migrate.go
@@ -40,18 +40,20 @@ func RunMigrations(ipfsRepoPath, newRepoPath string) error {
 		}
 	}()
 
+	// make a back up of the ipfs repo
 	err = copy.Copy(ipfsRepoPath, tmpDir)
 	if err != nil {
 		return fmt.Errorf("error backing up ipfs repo: %s", err)
 	}
 
+	// migrate the copied ipfs repo
 	os.Setenv("IPFS_PATH", tmpDir)
 	if err := Migrate(); err != nil {
 		return fmt.Errorf("error migrating ipfs repo: %s", err)
 	}
 
-	err = MoveIPFSRepoOntoPath(tmpDir, newRepoPath)
-	if err != nil {
+	// move migrated repo to new location
+	if err := os.Rename(tmpDir, newRepoPath); err != nil {
 		return fmt.Errorf("error moving repo onto new path: %s", err)
 	}
 

--- a/cafs/ipfs/migrate.go
+++ b/cafs/ipfs/migrate.go
@@ -2,22 +2,61 @@ package ipfs_filestore
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 
-	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
 	migrate "github.com/ipfs/go-ipfs/repo/fsrepo/migrations"
+	"github.com/otiai10/copy"
 )
 
 // ErrNeedMigration is an
 var ErrNeedMigration = fmt.Errorf(`ipfs: need datastore migration`)
 
+// RunMigrations takes an ipfsRepoPath and newRepoPath
+// it creates a copy of the ipfs repo, moves it to the
+// new repo path and migrates that repo
+// it cleans up any tmp directories made, and removes
+// the new repo if any errors occur
+// IT DOES NOT REMOVE THE ORIGINAL REPO
+func RunMigrations(ipfsRepoPath, newRepoPath string) error {
+	// create temp directory into which we will copy the
+	// ipfs directory
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "ipfs_temp")
+	if err != nil {
+		return err
+	}
+	rollback := func() {
+		os.RemoveAll(newRepoPath)
+	}
+	defer func() {
+		os.RemoveAll(tmpDir)
+		if rollback != nil {
+			rollback()
+		}
+	}()
+
+	err = copy.Copy(ipfsRepoPath, tmpDir)
+	if err != nil {
+		return err
+	}
+
+	err = MoveIPFSRepoOntoPath(tmpDir, newRepoPath)
+	if err != nil {
+		return err
+	}
+	rollback = nil
+	return nil
+}
+
 // Migrate runs an IPFS fsrepo migration
-func Migrate() error {
-	err := migrate.RunMigration(fsrepo.RepoVersion)
+func Migrate(prevVersion, newVersion int) error {
+	err := migrate.RunMigration(newVersion)
 	if err != nil {
 		fmt.Println("The migrations of fs-repo failed:")
 		fmt.Printf("  %s\n", err)
 		fmt.Println("If you think this is a bug, please file an issue and include this whole log output.")
 		fmt.Println("  https://github.com/ipfs/fs-repo-migrations")
+		return err
 	}
-	return err
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/mr-tron/base58 v1.1.3
 	github.com/multiformats/go-multihash v0.0.13
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/otiai10/copy v1.2.0
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -813,6 +813,13 @@ github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
+github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
+github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.1 h1:BCmzIS3n71sGfHB5NMNDB3lHYPz8fWSkCAErHed//qc=
+github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
`func RunMigrations(oldpath, newpath string) error`
- takes an old path
- copies the repo to a temp dir
- migrates the copied repo
- moves the migrated repo to the new location
- cleans up any temp dir
If there is any error, it removes the new repo 

**doesn't remove the original repo**

Created a small util program that moves and migrates repo and it works!!