### PR TITLE
fix(ipfs): relase IPFS repo lock with new ReleasingFilesystem interface

### DIFF
--- a/cafs/ipfs/filestore_test.go
+++ b/cafs/ipfs/filestore_test.go
@@ -25,6 +25,9 @@ func init() {
 }
 
 func TestFS(t *testing.T) {
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+
 	path := filepath.Join(os.TempDir(), "ipfs_cafs_test")
 	if err := os.MkdirAll(path, os.ModePerm); err != nil {
 		t.Errorf("error creating temp dir: %s", err.Error())
@@ -37,7 +40,7 @@ func TestFS(t *testing.T) {
 		return
 	}
 
-	f, err := NewFS(nil, func(c *StoreCfg) {
+	f, err := NewFS(ctx, nil, func(c *StoreCfg) {
 		c.Online = false
 		c.FsRepoPath = path
 	})
@@ -57,6 +60,9 @@ func TestFS(t *testing.T) {
 }
 
 func TestCreatedWithAPIAddrFS(t *testing.T) {
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+
 	path := filepath.Join(os.TempDir(), "ipfs_cafs_test_api_addr")
 	if err := os.MkdirAll(path, os.ModePerm); err != nil {
 		t.Errorf("error creating temp dir: %s", err.Error())
@@ -71,7 +77,7 @@ func TestCreatedWithAPIAddrFS(t *testing.T) {
 	}
 
 	// create an ipfs fs with that repo
-	_, err := NewFS(nil, func(c *StoreCfg) {
+	_, err := NewFS(ctx, nil, func(c *StoreCfg) {
 		c.Online = false
 		c.FsRepoPath = path
 		c.EnableAPI = true
@@ -82,7 +88,7 @@ func TestCreatedWithAPIAddrFS(t *testing.T) {
 	}
 
 	// attempt to create another filestore using the same repo
-	if _, err := NewFS(nil, func(c *StoreCfg) {
+	if _, err := NewFS(ctx, nil, func(c *StoreCfg) {
 		c.Online = false
 		c.FsRepoPath = path
 	}); err == nil {
@@ -90,7 +96,7 @@ func TestCreatedWithAPIAddrFS(t *testing.T) {
 	}
 
 	// create another filestore, but with a fallback api address
-	cafs, err := NewFS(nil, func(c *StoreCfg) {
+	cafs, err := NewFS(ctx, nil, func(c *StoreCfg) {
 		c.Online = false
 		c.FsRepoPath = path
 		c.APIAddr = "127.0.0.1:5001/api/v0/swarm/peers"
@@ -104,7 +110,9 @@ func TestCreatedWithAPIAddrFS(t *testing.T) {
 }
 
 func BenchmarkRead(b *testing.B) {
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+
 	path := filepath.Join(os.TempDir(), "ipfs_cafs_benchmark_read")
 
 	if _, err := os.Open(filepath.Join(path, "config")); os.IsNotExist(err) {
@@ -121,7 +129,7 @@ func BenchmarkRead(b *testing.B) {
 		defer os.RemoveAll(path)
 	}
 
-	f, err := NewFS(nil, func(c *StoreCfg) {
+	f, err := NewFS(ctx, nil, func(c *StoreCfg) {
 		c.Online = false
 		c.FsRepoPath = path
 	})

--- a/cafs/mapstore.go
+++ b/cafs/mapstore.go
@@ -22,7 +22,7 @@ func NewMapstore() *MapStore {
 }
 
 // NewMapFilesystem satisfies the qfs.FSConstructor interface
-func NewMapFilesystem(ctgMap map[string]interface{}) (qfs.Filesystem, error) {
+func NewMapFilesystem(_ context.Context, _ map[string]interface{}) (qfs.Filesystem, error) {
 	return NewMapstore(), nil
 }
 

--- a/fs.go
+++ b/fs.go
@@ -38,7 +38,16 @@ type Filesystem interface {
 }
 
 // FSConstructor is a function that creates a filesystem from a config map
-type FSConstructor func(cfg map[string]interface{}) (Filesystem, error)
+// the passed in context should last for the duration of the existence of the
+// store. Any resources allocated by the store should be scoped to this context
+type FSConstructor func(ctx context.Context, cfg map[string]interface{}) (Filesystem, error)
+
+// ReleasingFilesystem provides a channel to signal cleanup is finished. It
+// sends after a filesystem has closed & about to release all it's resources
+type ReleasingFilesystem interface {
+	Filesystem
+	Done() chan struct{}
+}
 
 // Destroyer is an optional interface to tear down a filesystem, removing all
 // persisted resources

--- a/httpfs/httpfs.go
+++ b/httpfs/httpfs.go
@@ -47,7 +47,7 @@ func mapToConfig(cfgMap map[string]interface{}) (*FSConfig, error) {
 }
 
 // NewFilesystem creates a new http filesystem PathResolver
-func NewFilesystem(cfgMap map[string]interface{}) (qfs.Filesystem, error) {
+func NewFilesystem(_ context.Context, cfgMap map[string]interface{}) (qfs.Filesystem, error) {
 	return NewFS(cfgMap)
 }
 

--- a/localfs/localfs.go
+++ b/localfs/localfs.go
@@ -50,7 +50,7 @@ func mapToConfig(cfgMap map[string]interface{}) (*FSConfig, error) {
 
 // NewFilesystem creates a new local filesystem Pathresolver
 // with no options
-func NewFilesystem(cfgMap map[string]interface{}) (qfs.Filesystem, error) {
+func NewFilesystem(_ context.Context, cfgMap map[string]interface{}) (qfs.Filesystem, error) {
 	return NewFS(cfgMap)
 }
 

--- a/mem.go
+++ b/mem.go
@@ -15,7 +15,7 @@ import (
 // NewMemFilesystem allocates an instace of a mapstore that
 // can be used as a PathResolver
 // satisfies the FSConstructor interface
-func NewMemFilesystem(cfg map[string]interface{}) (Filesystem, error) {
+func NewMemFilesystem(_ context.Context, cfg map[string]interface{}) (Filesystem, error) {
 	return NewMemFS(), nil
 }
 


### PR DESCRIPTION
A Releasing Filesystem mimics the pattern of context.Context.Done(), adding a
done channel that the owner sends on when resources have been released (as a
result of a cancelled filesystem context).

This `Done` pattern gives us control over the timing & sequencing of held
resources like the IPFS repo lock.

makes progress on qri-io/qri#1375