### PR TITLE
refactor(muxfs): rework muxfs API

### DIFF
--- a/cafs/castore.go
+++ b/cafs/castore.go
@@ -25,7 +25,7 @@ type Filestore interface {
 	// Put places a file or a directory in the store.
 	// The most notable difference from a standard file store is the store itself
 	// determines the resulting path. paths returned by put must be prefixed with
-	// the PathPrefix:
+	// the type:
 	// eg. /ipfs/QmZ3KfGaSrb3cnTriJbddCzG7hwQi2j6km7Xe7hVpnsW5S
 	Put(ctx context.Context, file qfs.File) (path string, err error)
 
@@ -49,10 +49,10 @@ type Filestore interface {
 	// "wrap" sets weather the top level should be wrapped in a directory
 	NewAdder(pin, wrap bool) (Adder, error)
 
-	// PathPrefix is a top-level identifier to distinguish between filestores,
+	// Type is a top-level identifier to distinguish between filestores,
 	// for exmple: the "ipfs" in /ipfs/QmZ3KfGaSrb3cnTriJbddCzG7hwQi2j6km7Xe7hVpnsW5S
 	// a Filestore implementation should always return the same
-	PathPrefix() string
+	Type() string
 }
 
 // Fetcher is the interface for getting files from a remote source

--- a/cafs/mapstore.go
+++ b/cafs/mapstore.go
@@ -57,9 +57,12 @@ type MapStore struct {
 	Files   map[string]filer
 }
 
-// PathPrefix returns the prefix on paths in the store
-func (m MapStore) PathPrefix() string {
-	return "map"
+// MapFilestoreType uniquely identifies the map filestore
+const MapFilestoreType = "map"
+
+// Type distinguishes this filesystem from others by a unique string prefix
+func (m MapStore) Type() string {
+	return MapFilestoreType
 }
 
 // AddConnection sets up pointers from this MapStore to that, and vice versa.

--- a/cafs/test/mapstore_test.go
+++ b/cafs/test/mapstore_test.go
@@ -17,8 +17,8 @@ func TestMemFilestore(t *testing.T) {
 	// }
 }
 
-func TestPathPrefix(t *testing.T) {
-	got := cafs.NewMapstore().PathPrefix()
+func TestType(t *testing.T) {
+	got := cafs.NewMapstore().Type()
 	if "map" != got {
 		t.Errorf("path prefix mismatch. expected: 'map', got: %s", got)
 	}

--- a/cafs/test/test.go
+++ b/cafs/test/test.go
@@ -30,9 +30,9 @@ func EnsureFilestoreSingleFileBehavior(f cafs.Filestore) error {
 		return fmt.Errorf("Filestore.Put(%s) error: %s", file.FileName(), err.Error())
 	}
 
-	pre := "/" + f.PathPrefix() + "/"
+	pre := "/" + f.Type() + "/"
 	if !strings.HasPrefix(key, pre) {
-		return fmt.Errorf("key returned didn't return a that matches this Filestore's PathPrefix. Expected: %s/..., got: %s", pre, key)
+		return fmt.Errorf("key returned didn't return a that matches this Filestore's Type. Expected: %s/..., got: %s", pre, key)
 	}
 
 	outf, err := f.Get(ctx, key)

--- a/fs.go
+++ b/fs.go
@@ -20,8 +20,6 @@ type PathResolver interface {
 }
 
 // Filesystem abstracts & unifies filesystem-like behaviour
-// For now it's just a wrapper around PathResolver, but it'll expand once we merge
-// write-like functionality from cafs
 type Filesystem interface {
 	// Get fetching files and directories from path strings.
 	// in practice path strings can be things like:
@@ -37,10 +35,16 @@ type Filesystem interface {
 	Delete(ctx context.Context, path string) (err error)
 }
 
-// FSConstructor is a function that creates a filesystem from a config map
+// Config binds a filesystem type to a configuration map
+type Config struct {
+	Type   string                 `json:"type"`
+	Config map[string]interface{} `json:"config,omitempty"`
+}
+
+// Constructor is a function that creates a filesystem from a config map
 // the passed in context should last for the duration of the existence of the
 // store. Any resources allocated by the store should be scoped to this context
-type FSConstructor func(ctx context.Context, cfg map[string]interface{}) (Filesystem, error)
+type Constructor func(ctx context.Context, cfg map[string]interface{}) (Filesystem, error)
 
 // ReleasingFilesystem provides a channel to signal cleanup is finished. It
 // sends after a filesystem has closed & about to release all it's resources

--- a/fs.go
+++ b/fs.go
@@ -21,6 +21,11 @@ type PathResolver interface {
 
 // Filesystem abstracts & unifies filesystem-like behaviour
 type Filesystem interface {
+	// Type returns a string identifier that distinguishes a filesystem from
+	// all other implementations, example identifiers include: "local", "ipfs",
+	// and "http"
+	// types are used as path prefixes when multiplexing filesystems
+	Type() string
 	// Get fetching files and directories from path strings.
 	// in practice path strings can be things like:
 	// * a local filesystem

--- a/httpfs/httpfs.go
+++ b/httpfs/httpfs.go
@@ -51,6 +51,14 @@ func NewFilesystem(_ context.Context, cfgMap map[string]interface{}) (qfs.Filesy
 	return NewFS(cfgMap)
 }
 
+// FS is a implementation of qfs.PathResolver that uses the local filesystem
+type FS struct {
+	cfg *FSConfig
+}
+
+// compile-time assertion that MapStore satisfies the Filesystem interface
+var _ qfs.Filesystem = (*FS)(nil)
+
 // NewFS creates a new local filesytem PathResolver
 func NewFS(cfgMap map[string]interface{}, opts ...Option) (qfs.Filesystem, error) {
 	cfg, err := mapToConfig(cfgMap)
@@ -65,13 +73,13 @@ func NewFS(cfgMap map[string]interface{}, opts ...Option) (qfs.Filesystem, error
 	return &FS{cfg: cfg}, nil
 }
 
-// FS is a implementation of qfs.PathResolver that uses the local filesystem
-type FS struct {
-	cfg *FSConfig
-}
+// FilestoreType uniquely identifies this filestore
+const FilestoreType = "http"
 
-// compile-time assertion that MapStore satisfies the Filesystem interface
-var _ qfs.Filesystem = (*FS)(nil)
+// Type distinguishes this filesystem from others by a unique string prefix
+func (httpfs *FS) Type() string {
+	return FilestoreType
+}
 
 // Get implements qfs.PathResolver
 func (httpfs *FS) Get(ctx context.Context, path string) (qfs.File, error) {

--- a/localfs/localfs.go
+++ b/localfs/localfs.go
@@ -76,6 +76,14 @@ type FS struct {
 // compile-time assertion that MapStore satisfies the Filesystem interface
 var _ qfs.Filesystem = (*FS)(nil)
 
+// FilestoreType uniquely identifies this filestore
+const FilestoreType = "local"
+
+// Type distinguishes this filesystem from others by a unique string prefix
+func (lfs *FS) Type() string {
+	return FilestoreType
+}
+
 // Get implements qfs.PathResolver
 func (lfs *FS) Get(ctx context.Context, path string) (qfs.File, error) {
 	fi, err := os.Stat(path)

--- a/muxfs/mux_test.go
+++ b/muxfs/mux_test.go
@@ -25,7 +25,7 @@ func TestDefaultNewMux(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	cfg := []MuxConfig{
+	cfg := []qfs.Config{
 		{Type: "ipfs", Config: map[string]interface{}{"path": path}},
 		{Type: "http"},
 		{Type: "local"},
@@ -56,7 +56,7 @@ func TestDefaultNewMux(t *testing.T) {
 
 func TestOptSetIPFSPathWithConfig(t *testing.T) {
 	// test empty muxConfig
-	o := &[]MuxConfig{
+	o := &[]qfs.Config{
 		{
 			Type:   "ipfs",
 			Config: map[string]interface{}{"path": "bad/path"},
@@ -64,10 +64,10 @@ func TestOptSetIPFSPathWithConfig(t *testing.T) {
 	}
 	path := "test/path"
 	OptSetIPFSPath(path)(o)
-	var ipfscfg MuxConfig
+	var ipfscfg qfs.Config
 
 	if len(*o) != 1 {
-		t.Errorf("expected MuxConfig slice to have length 1, got %d", len(*o))
+		t.Errorf("expected qfs.Config slice to have length 1, got %d", len(*o))
 		return
 	}
 	for _, mc := range *o {
@@ -77,7 +77,7 @@ func TestOptSetIPFSPathWithConfig(t *testing.T) {
 		}
 	}
 	if ipfscfg.Type != "ipfs" {
-		t.Errorf("expected MuxConfig of type 'ipfs' to exist, got %s", ipfscfg.Type)
+		t.Errorf("expected qfs.Config of type 'ipfs' to exist, got %s", ipfscfg.Type)
 		return
 	}
 	gotPath, ok := ipfscfg.Config["path"]
@@ -92,24 +92,24 @@ func TestOptSetIPFSPathWithConfig(t *testing.T) {
 
 func TestOptSetIPFSPathEmptyConfig(t *testing.T) {
 	// nil should error
-	var o *[]MuxConfig
+	var o *[]qfs.Config
 	path := "test/path"
 	if err := OptSetIPFSPath(path)(o); err == nil {
-		t.Errorf("expected error when using nil MuxConfig, but didn't get one")
+		t.Errorf("expected error when using nil qfs.Config, but didn't get one")
 		return
 	}
 
 	// test empty muxConfig
-	o = &[]MuxConfig{}
+	o = &[]qfs.Config{}
 	if err := OptSetIPFSPath(path)(o); err != nil {
 		t.Errorf("unexpected error when setting ipfs path: %s", err)
 		return
 	}
 
-	var ipfscfg MuxConfig
+	var ipfscfg qfs.Config
 
 	if len(*o) != 1 {
-		t.Errorf("expected MuxConfig slice to have length 1, got %d", len(*o))
+		t.Errorf("expected qfs.Config slice to have length 1, got %d", len(*o))
 		return
 	}
 	for _, mc := range *o {
@@ -119,7 +119,7 @@ func TestOptSetIPFSPathEmptyConfig(t *testing.T) {
 		}
 	}
 	if ipfscfg.Type != "ipfs" {
-		t.Errorf("expected MuxConfig of type 'ipfs' to exist, got %s", ipfscfg.Type)
+		t.Errorf("expected qfs.Config of type 'ipfs' to exist, got %s", ipfscfg.Type)
 		return
 	}
 	gotPath, ok := ipfscfg.Config["path"]
@@ -154,7 +154,7 @@ func TestCAFSFromIPFS(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	cfg := []MuxConfig{
+	cfg := []qfs.Config{
 		{Type: "ipfs", Config: map[string]interface{}{"path": path}},
 	}
 	mfs, err := New(ctx, cfg)
@@ -175,7 +175,7 @@ func TestRepoLockPerContext(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := []MuxConfig{
+	cfg := []qfs.Config{
 		{
 			Type: "ipfs",
 			Config: map[string]interface{}{

--- a/muxfs/mux_test.go
+++ b/muxfs/mux_test.go
@@ -37,105 +37,26 @@ func TestDefaultNewMux(t *testing.T) {
 		t.Errorf("error creating new mux: %s", err)
 		return
 	}
-	if _, err := GetResolver(mfs, "ipfs"); err != nil {
-		t.Errorf(err.Error())
-	}
-	if _, err := GetResolver(mfs, "http"); err != nil {
-		t.Errorf(err.Error())
-	}
-	if _, err := GetResolver(mfs, "local"); err != nil {
-		t.Errorf(err.Error())
-	}
-	if _, err := GetResolver(mfs, "mem"); err != nil {
-		t.Errorf(err.Error())
-	}
-	if _, err := GetResolver(mfs, "map"); err != nil {
-		t.Errorf(err.Error())
-	}
-}
-
-func TestOptSetIPFSPathWithConfig(t *testing.T) {
-	// test empty muxConfig
-	o := &[]qfs.Config{
-		{
-			Type:   "ipfs",
-			Config: map[string]interface{}{"path": "bad/path"},
-		},
-	}
-	path := "test/path"
-	OptSetIPFSPath(path)(o)
-	var ipfscfg qfs.Config
-
-	if len(*o) != 1 {
-		t.Errorf("expected qfs.Config slice to have length 1, got %d", len(*o))
-		return
-	}
-	for _, mc := range *o {
-		if mc.Type == "ipfs" {
-			ipfscfg = mc
-			break
+	for _, fsType := range []string{
+		"ipfs",
+		"http",
+		"local",
+		"mem",
+		"map",
+	} {
+		if mfs.Filesystem(fsType) == nil {
+			t.Errorf("expected filesystem for %q, got nil", fsType)
 		}
 	}
-	if ipfscfg.Type != "ipfs" {
-		t.Errorf("expected qfs.Config of type 'ipfs' to exist, got %s", ipfscfg.Type)
-		return
-	}
-	gotPath, ok := ipfscfg.Config["path"]
-	if !ok {
-		t.Errorf("expected ipfs map[string]interface config to have field 'fsRepoPath', but it does not")
-		return
-	}
-	if gotPath != path {
-		t.Errorf("expected fsRepoPath to be '%s', got '%s'", path, gotPath)
+	if mfs.Filesystem("nonexistent") != nil {
+		t.Errorf("expected nonexistent filesystem to return nil")
 	}
 }
 
-func TestOptSetIPFSPathEmptyConfig(t *testing.T) {
-	// nil should error
-	var o *[]qfs.Config
-	path := "test/path"
-	if err := OptSetIPFSPath(path)(o); err == nil {
-		t.Errorf("expected error when using nil qfs.Config, but didn't get one")
-		return
-	}
-
-	// test empty muxConfig
-	o = &[]qfs.Config{}
-	if err := OptSetIPFSPath(path)(o); err != nil {
-		t.Errorf("unexpected error when setting ipfs path: %s", err)
-		return
-	}
-
-	var ipfscfg qfs.Config
-
-	if len(*o) != 1 {
-		t.Errorf("expected qfs.Config slice to have length 1, got %d", len(*o))
-		return
-	}
-	for _, mc := range *o {
-		if mc.Type == "ipfs" {
-			ipfscfg = mc
-			break
-		}
-	}
-	if ipfscfg.Type != "ipfs" {
-		t.Errorf("expected qfs.Config of type 'ipfs' to exist, got %s", ipfscfg.Type)
-		return
-	}
-	gotPath, ok := ipfscfg.Config["path"]
-	if !ok {
-		t.Errorf("expected ipfs map[string]interface config to have field 'path', but it does not")
-		return
-	}
-	if gotPath != path {
-		t.Errorf("expected fsRepoPath to be '%s', got '%s'", path, gotPath)
-	}
-}
-
-func TestCAFSFromIPFS(t *testing.T) {
+func TestDefaultWriteFS(t *testing.T) {
 	// create a mux that does NOT hav an ipfsFS
 	mfs := &Mux{}
-	ipfsFS := mfs.CAFSStoreFromIPFS()
+	ipfsFS := mfs.DefaultWriteFS()
 	if ipfsFS != nil {
 		t.Errorf("expected nil return on an empty mux fs")
 	}
@@ -162,7 +83,7 @@ func TestCAFSFromIPFS(t *testing.T) {
 		t.Errorf("error creating new mux")
 		return
 	}
-	ipfsFS = mfs.CAFSStoreFromIPFS()
+	ipfsFS = mfs.DefaultWriteFS()
 	if ipfsFS == nil {
 		t.Errorf("expected ipfsFS to exist, got nil")
 		return

--- a/qipfs/filestore.go
+++ b/qipfs/filestore.go
@@ -80,6 +80,7 @@ func NewFilesystem(ctx context.Context, cfgMap map[string]interface{}) (qfs.File
 			// attempt to create and return an `qipfs_http` filesystem istead
 			return qipfs_http.NewFilesystem(map[string]interface{}{"url": cfg.URL})
 		}
+		log.Errorf("opening %q: %s", cfg.Path, err)
 		return nil, err
 	}
 
@@ -139,11 +140,12 @@ func NewFilesystemFromNode(node *core.IpfsNode) (qfs.Filesystem, error) {
 	}, nil
 }
 
-const prefix = "ipfs"
+// FilestoreType uniquely identifies this filestore
+const FilestoreType = "ipfs"
 
-// PathPrefix returns the muxing prefix this filesystem handles: "ipfs"
-func (fst Filestore) PathPrefix() string {
-	return prefix
+// Type distinguishes this filesystem from others by a unique string prefix
+func (fst Filestore) Type() string {
+	return FilestoreType
 }
 
 // Done implements the qfs.ReleasingFilesystem interface
@@ -383,7 +385,7 @@ func (fst *Filestore) NewAdder(pin, wrap bool) (cafs.Adder, error) {
 }
 
 func pathFromHash(hash string) string {
-	return fmt.Sprintf("/%s/%s", prefix, hash)
+	return fmt.Sprintf("/%s/%s", FilestoreType, hash)
 }
 
 // AddFile adds a file to the top level IPFS Node

--- a/qipfs/migrate.go
+++ b/qipfs/migrate.go
@@ -1,30 +1,39 @@
 package qipfs
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
 	migrate "github.com/ipfs/go-ipfs/repo/fsrepo/migrations"
 	"github.com/otiai10/copy"
 )
 
-// ErrNeedMigration is an
+const configFilename = "config"
+
+// ErrNeedMigration indicates a migration must be run before qipfs can be used
 var ErrNeedMigration = fmt.Errorf(`ipfs: need datastore migration`)
 
-// RunMigrations takes an ipfsRepoPath and newRepoPath
+// InternalizeIPFSRepo takes an ipfsRepoPath and newRepoPath
 // it creates a copy of the ipfs repo, moves it to the
 // new repo path and migrates that repo
 // it cleans up any tmp directories made, and removes
 // the new repo if any errors occur
 // IT DOES NOT REMOVE THE ORIGINAL REPO
-func RunMigrations(ipfsRepoPath, newRepoPath string) error {
+func InternalizeIPFSRepo(ipfsRepoPath, newRepoPath string) error {
+	// bail if a config file already exists at new repo path
+	if _, err := os.Stat(filepath.Join(newRepoPath, configFilename)); err == nil {
+		return fmt.Errorf("repo already exists at new location")
+	}
+
 	// create temp directory into which we will copy the
 	// ipfs directory
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "ipfs_temp")
 	if err != nil {
-		return fmt.Errorf("error creating temp directory: %s", err)
+		return fmt.Errorf("error creating temp directory: %w", err)
 	}
 
 	rollback := func() {
@@ -43,18 +52,22 @@ func RunMigrations(ipfsRepoPath, newRepoPath string) error {
 	// make a back up of the ipfs repo
 	err = copy.Copy(ipfsRepoPath, tmpDir)
 	if err != nil {
-		return fmt.Errorf("error backing up ipfs repo: %s", err)
+		return fmt.Errorf("error backing up ipfs repo: %w", err)
 	}
 
 	// migrate the copied ipfs repo
 	os.Setenv("IPFS_PATH", tmpDir)
 	if err := Migrate(); err != nil {
-		return fmt.Errorf("error migrating ipfs repo: %s", err)
+		return fmt.Errorf("error migrating ipfs repo: %w", err)
 	}
 
 	// move migrated repo to new location
 	if err := os.Rename(tmpDir, newRepoPath); err != nil {
-		return fmt.Errorf("error moving repo onto new path: %s", err)
+		return fmt.Errorf("error moving repo onto new path: %w", err)
+	}
+
+	if err := migrateToInternalIPFSConfig(ipfsRepoPath, newRepoPath); err != nil {
+		return fmt.Errorf("internalizing repo configuration: %w", err)
 	}
 
 	rollback = nil
@@ -72,4 +85,33 @@ func Migrate() error {
 		return err
 	}
 	return nil
+}
+
+func migrateToInternalIPFSConfig(repoReadPath, repoWritePath string) error {
+	cfg := map[string]interface{}{}
+	data, err := ioutil.ReadFile(filepath.Join(repoReadPath, configFilename))
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return err
+	}
+
+	cfg["Addresses"] = map[string]interface{}{
+		"Swarm": []interface{}{
+			"/ip4/0.0.0.0/tcp/0",
+			"/ip6/::/tcp/0",
+		},
+		"Announce":   []interface{}{},
+		"NoAnnounce": []interface{}{},
+		"API":        "/ip4/127.0.0.1/tcp/0",
+		"Gateway":    "/ip4/127.0.0.1/tcp/0",
+	}
+
+	data, err = json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(filepath.Join(repoWritePath, configFilename), data, 0666)
 }

--- a/qipfs/qipfs_http/filestore.go
+++ b/qipfs/qipfs_http/filestore.go
@@ -61,10 +61,12 @@ func (fst *Filestore) IPFSCoreAPI() coreiface.CoreAPI {
 	return fst.capi
 }
 
-const prefix = "ipfs"
+// FilestoreType uniquely identifies this filestore
+const FilestoreType = "ipfs"
 
-func (fst Filestore) PathPrefix() string {
-	return prefix
+// Type distinguishes this filesystem from others by a unique string prefix
+func (fst Filestore) Type() string {
+	return FilestoreType
 }
 
 // Online always returns true
@@ -128,7 +130,7 @@ func (fst *Filestore) NewAdder(pin, wrap bool) (cafs.Adder, error) {
 }
 
 func pathFromHash(hash string) string {
-	return fmt.Sprintf("/%s/%s", prefix, hash)
+	return fmt.Sprintf("/%s/%s", FilestoreType, hash)
 }
 
 // AddFile adds a file to the top level IPFS Node


### PR DESCRIPTION
A number of adjustments to make working with qfs easier higher up in the stack. The most important is introducing a "default write destination", which for now is just the first filesystem a muxfs is given that supports the cafs.Filstore interface. In the future we can add a field to qfs.Config for manual control of defaults.

Other notable changes:

* add `Type()` method to Filesystems, drop cafs.PathPrefix, use this instead of
  requiring a type string argument when adding a filesystem
* adjust muxfs filesystem getters & setters, use setter in New constructor,
  getter now only returns nil if the requested filesystem doesn't exist
* drop `CAFSStoreFromIPFS` for `DefaultWriteFS`, which may or may not be an IPFS
  fielsystem. For IPFS-specific behaviour, use `muxfs.Filesystem(qipfs.FilestoreType)`
  to get the qipfs filesystem