### PR TITLE
feat(qipfs): add QUIC swarm listeners when internalizing repo

### DIFF
--- a/qipfs/migrate.go
+++ b/qipfs/migrate.go
@@ -101,6 +101,8 @@ func migrateToInternalIPFSConfig(repoReadPath, repoWritePath string) error {
 		"Swarm": []interface{}{
 			"/ip4/0.0.0.0/tcp/0",
 			"/ip6/::/tcp/0",
+			"/ip4/0.0.0.0/udp/0/quic",
+			"/ip6/::/udp/0/quic",
 		},
 		"Announce":   []interface{}{},
 		"NoAnnounce": []interface{}{},


### PR DESCRIPTION
ipfs v0.6.0 includes quic transport listeners as part of it's migration scheme, we should too!