### PR TITLE
feat(qipfs): add `DisableBootstrap` as qipfs config option

### DIFF
--- a/qipfs/config.go
+++ b/qipfs/config.go
@@ -24,6 +24,8 @@ type StoreCfg struct {
 	// enable experimental IPFS pubsub service. does not apply when
 	// operating over HTTP via a URL
 	EnablePubSub bool
+	// DisableBootstrap will remove the bootstrap addrs from the node
+	DisableBootstrap bool
 }
 
 func mapToConfig(cfgmap map[string]interface{}) (*StoreCfg, error) {

--- a/qipfs/filestore.go
+++ b/qipfs/filestore.go
@@ -90,6 +90,14 @@ func NewFilesystem(ctx context.Context, cfgMap map[string]interface{}) (qfs.File
 		return nil, fmt.Errorf("error creating ipfs node: %s", err.Error())
 	}
 
+	if cfg.DisableBootstrap {
+		repoCfg, err := node.Repo.Config()
+		if err != nil {
+			return nil, err
+		}
+		repoCfg.Bootstrap = []string{}
+	}
+
 	capi, err := coreapi.NewCoreAPI(node)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This flag will let us know to temporarily remove the Bootstrap addrs
from the underlying ipfs repo's config.

This has been confirmed to work via testgrounds

closes #41 