### PR TITLE
fix(linux): migration fix for copying on cross link device

### DIFF
--- a/qipfs/migrate.go
+++ b/qipfs/migrate.go
@@ -63,7 +63,10 @@ func InternalizeIPFSRepo(ipfsRepoPath, newRepoPath string) error {
 
 	// move migrated repo to new location
 	if err := os.Rename(tmpDir, newRepoPath); err != nil {
-		return fmt.Errorf("error moving repo onto new path: %w", err)
+		copyErr := copy.Copy(tmpDir, newRepoPath)
+		if copyErr != nil {
+			return fmt.Errorf("error moving repo onto new path: %w", copyErr)
+		}
 	}
 
 	if err := migrateToInternalIPFSConfig(ipfsRepoPath, newRepoPath); err != nil {


### PR DESCRIPTION
If rename fails we attempt to copy the dir instead. The defered function does the cleanup of `tmpDir`.

Tested in a dockerized environment.