### PR TITLE
feat(qipfs): add optional ListeningAddrs config field

### DIFF
--- a/qipfs/config.go
+++ b/qipfs/config.go
@@ -26,6 +26,9 @@ type StoreCfg struct {
 	EnablePubSub bool
 	// DisableBootstrap will remove the bootstrap addrs from the node
 	DisableBootstrap bool
+	// AdditionalSwarmListeningAddrs allows you to add a list of
+	// addresses you want the underlying libp2p swarm to listen on
+	AdditionalSwarmListeningAddrs []string
 }
 
 func mapToConfig(cfgmap map[string]interface{}) (*StoreCfg, error) {

--- a/qipfs/filestore.go
+++ b/qipfs/filestore.go
@@ -87,7 +87,7 @@ func NewFilesystem(ctx context.Context, cfgMap map[string]interface{}) (qfs.File
 
 	node, err := core.NewNode(ctx, &cfg.BuildCfg)
 	if err != nil {
-		return nil, fmt.Errorf("error creating ipfs node: %s", err.Error())
+		return nil, fmt.Errorf("qipfs: error creating ipfs node: %w", err)
 	}
 
 	if cfg.DisableBootstrap {
@@ -96,6 +96,14 @@ func NewFilesystem(ctx context.Context, cfgMap map[string]interface{}) (qfs.File
 			return nil, err
 		}
 		repoCfg.Bootstrap = []string{}
+	}
+
+	if len(cfg.AdditionalSwarmListeningAddrs) != 0 {
+		repoCfg, err := node.Repo.Config()
+		if err != nil {
+			return nil, err
+		}
+		repoCfg.Addresses.Swarm = append(repoCfg.Addresses.Swarm, cfg.AdditionalSwarmListeningAddrs...)
 	}
 
 	capi, err := coreapi.NewCoreAPI(node)


### PR DESCRIPTION
Can now give a slice of strings of addrs you explicitily want your
underlying ipfs node to listen on

@b5 this seemed like the most logic in-road to getting custom `ListeningAddrs` into ipfs, since the `Filesystems` config has become our gateway to allowing qri users to alter the ipfs config without having to touch the ipfs config. But not sure that's really how we want to use it long term since I'm having a hard time justifying why something named `Filesystems` has fields like `DisableBootstrap` and `ListeningAddrs`, which seem like network config options, not filesystem config options. But, this might just be cognitive dissonance on my part, since ipfs is indeed both a filesystem and a network.