### PR TITLE
fix(qipfs): use passed-in arg for migration

### DIFF
--- a/qipfs/migrate.go
+++ b/qipfs/migrate.go
@@ -57,8 +57,7 @@ func InternalizeIPFSRepo(ipfsRepoPath, newRepoPath string) error {
 	}
 
 	// migrate the copied ipfs repo
-	os.Setenv("IPFS_PATH", tmpDir)
-	if err := Migrate(context.Background(), ""); err != nil {
+	if err := Migrate(context.Background(), tmpDir); err != nil {
 		return fmt.Errorf("error migrating ipfs repo: %w", err)
 	}
 


### PR DESCRIPTION
switch from an older method of setting the IPFS_PATH env var, utilize migration argument instead.